### PR TITLE
Improve shunk failing data output

### DIFF
--- a/mocha-check.js
+++ b/mocha-check.js
@@ -1,4 +1,5 @@
 var testcheck = require('testcheck');
+var javascriptStringify = require('javascript-stringify');
 
 function install(globalObj) {
   globalObj = globalObj || global || window;
@@ -58,7 +59,7 @@ function check(options, argGens, propertyFn) {
 
 function printValues(values) {
   return '( ' + values.map(function (v) {
-    return JSON.stringify(v);
+    return javascriptStringify(v);
   }).join(', ') + ' )';
 }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "main": "mocha-check.js",
   "dependencies": {
+    "javascript-stringify": "^1.0.1",
     "testcheck": "^0.1.0"
   },
   "devDependencies": {

--- a/test/check.js
+++ b/test/check.js
@@ -24,4 +24,14 @@ describe('check', function () {
     assert(typeof x === 'number');
   })
 
+  it('outputs well formed shrunk data', function () {
+    try {
+      check.it('will fail with this assertion', { times: 1 }, [gen.return(NaN)], function (x) {
+        assert(x === 'this fails')
+      }).fn()
+    } catch(e) {
+      assert(e.message.indexOf('( NaN )') > -1);
+    }
+  })
+
 });


### PR DESCRIPTION
JSON.stringify won't correctly output data
that is not of a type allowed by the JSON
spec. This could cause misleading output.

This closes #2 